### PR TITLE
Reset the property value instead of unsetting the property from the object

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -48,7 +48,7 @@ if (!extension_loaded("pthreads")) {
 		}
 
 		public function shutdown() {
-			unset($this->workers);
+			$this->workers = null;
 		}
 
 		protected $workers;


### PR DESCRIPTION
The property should still exist in the object, even though we want to reset the value in it.
