### PR TITLE
Improve the travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: php
 
+sudo: false
+
 php:
   - 7.0
 
 install:
   - composer install
 
+before_script:
+  - git clone https://github.com/krakjoe/pthreads
+  - cd pthreads && phpize && ./configure && make install && cd ../
+
 script:
   - phpdbg -qrr vendor/bin/phpunit tests --coverage-text
-  - git clone https://github.com/krakjoe/pthreads
-  - cd pthreads && phpize && ./configure && sudo make install && cd ../
   - php -dextension=pthreads.so vendor/bin/phpunit tests


### PR DESCRIPTION
- avoid using sudo to install the extension (Travis installs PHP in folders owned by the current user), which allows to use the newer and faster infrastructure
- compile pthreads in before_script so that the compilation output gets collapsed to make the build output more readable
