### PR TITLE
Add the phpunit configuration file

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="all">
+            <directory suffix="Test.php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
This is required to be able to generate the code coverage, as PHPUnit 5 requires defining a whitelist when asking for code coverage instead of covering everything by default.
