### PR TITLE
Fix the order of assertion arguments

### DIFF
--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -14,7 +14,7 @@ class PoolTestWorker extends Worker {
 
 class PoolTestWork extends Threaded implements Collectable {
 	public function run() {
-		$this->hasWorker = 
+		$this->hasWorker =
 			$this->worker instanceof Worker;
 		$this->hasWorkerStd =
 			$this->worker->std instanceof stdClass;
@@ -54,12 +54,12 @@ class PoolTest extends PHPUnit_Framework_TestCase {
 		$pool->submitTo(0, new PoolTestWork()); # nothing to assert, no exceptions please
 		$pool->shutdown();
 
-		$this->assertEquals($work->hasWorker, true);
-		$this->assertEquals($work->hasWorkerStd, true);
-		$this->assertEquals($work->hasWorkerThreaded, true);		
+		$this->assertTrue($work->hasWorker);
+		$this->assertTrue($work->hasWorkerStd);
+		$this->assertTrue($work->hasWorkerThreaded);
 	}
-	
-	
+
+
 	public function testPoolGc() {
 		$pool = new Pool(1, PoolTestWorker::class, [new stdClass, new Threaded]);
 		$work = new PoolTestWork();
@@ -68,7 +68,7 @@ class PoolTest extends PHPUnit_Framework_TestCase {
 			$pool->submit(new PoolTestWork()); # nothing to assert, no exceptions please
 		}
 		$pool->submitTo(0, new PoolTestWork()); # nothing to assert, no exceptions please
-		
+
 		/* synchronize with pool */
 		$sync = new PoolTestSync();
 		$pool->submit($sync);
@@ -78,7 +78,7 @@ class PoolTest extends PHPUnit_Framework_TestCase {
 		}, $sync);
 
 		$pool->collect(function($task){
-			$this->assertEquals($task->isGarbage(), true);
+			$this->assertTrue($task->isGarbage());
 			return true;
 		});
 		$pool->shutdown();

--- a/tests/ThreadTest.php
+++ b/tests/ThreadTest.php
@@ -3,7 +3,7 @@ class TestThread extends Thread { # This should be more than one anon class, PHP
 
 	public function run() {
 		$this->member = "something";
-		$this->running = 
+		$this->running =
 			$this->isRunning();
 	}
 
@@ -14,11 +14,11 @@ class ThreadTest extends PHPUnit_Framework_TestCase {
 
 	public function testThreadStartAndJoin() {
 		$thread = new TestThread();
-		$this->assertEquals($thread->start(), true);
-		$this->assertEquals($thread->isStarted(), true);
-		$this->assertEquals($thread->join(), true);
-		$this->assertEquals($thread->isJoined(), true);
-		$this->assertEquals($thread->member, "something");
+		$this->assertTrue($thread->start());
+		$this->assertTrue($thread->isStarted());
+		$this->assertTrue($thread->join());
+		$this->assertTrue($thread->isJoined());
+		$this->assertEquals("something", $thread->member);
 	}
 
 	/**
@@ -26,8 +26,8 @@ class ThreadTest extends PHPUnit_Framework_TestCase {
 	*/
 	public function testThreadAlreadyStarted() {
 		$thread = new Thread();
-		$this->assertEquals($thread->start(), true);
-		$this->assertEquals($thread->start(), false);
+		$this->assertTrue($thread->start());
+		$this->assertFalse($thread->start());
 	}
 
 	/**
@@ -35,22 +35,22 @@ class ThreadTest extends PHPUnit_Framework_TestCase {
 	*/
 	public function testThreadAlreadyJoined() {
 		$thread = new Thread();
-		$this->assertEquals($thread->start(), true);
-		$this->assertEquals($thread->join(), true);
-		$this->assertEquals($thread->join(), false);
+		$this->assertTrue($thread->start());
+		$this->assertTrue($thread->join());
+		$this->assertFalse($thread->join());
 	}
 
 	public function testThreadIsRunning() {
 		$thread = new TestThread();
-		$this->assertEquals($thread->start(), true);
-		$this->assertEquals($thread->join(), true);
-		$this->assertEquals($thread->running, true);
+		$this->assertTrue($thread->start());
+		$this->assertTrue($thread->join());
+		$this->assertTrue($thread->running);
 	}
 
 	public function testThreadIds() {
 		$thread = new Thread();
 		$this->assertInternalType("int", $thread->getThreadId());
-		$this->assertInternalType("int", Thread::getCurrentThreadId());	
+		$this->assertInternalType("int", Thread::getCurrentThreadId());
 	}
 }
 ?>

--- a/tests/ThreadedTest.php
+++ b/tests/ThreadedTest.php
@@ -3,43 +3,43 @@ class ThreadedTest extends PHPUnit_Framework_TestCase {
 	public function testThreadedArrayAccessSet() {
 		$threaded = new Threaded();
 		$threaded[] = "something";
-		$this->assertEquals($threaded[0], "something");
+		$this->assertEquals("something", $threaded[0]);
 	}
 
 	public function testThreadedOverloadSetUnset() {
 		$threaded = new Threaded();
-		$threaded->something = "something";	
-		$this->assertEquals($threaded->something, "something");
+		$threaded->something = "something";
+		$this->assertEquals("something", $threaded->something);
 	}
 
 	public function testThreadedArrayAccessExistsUnset() {
 		$threaded = new Threaded();
-		$threaded[] = "something";	
-		$this->assertEquals(isset($threaded[0]), true);
+		$threaded[] = "something";
+		$this->assertTrue(isset($threaded[0]));
 		unset($threaded[0]);
-		$this->assertEquals(isset($threaded[0]), false);
+		$this->assertFalse(isset($threaded[0]));
 	}
 
 	public function testThreadedOverloadExistsUnset() {
 		$threaded = new Threaded();
-		$threaded->something = "something";	
-		$this->assertEquals(isset($threaded->something), true);
+		$threaded->something = "something";
+		$this->assertTrue(isset($threaded->something));
 		unset($threaded->something);
-		$this->assertEquals(isset($threaded->something), false);
+		$this->assertFalse(isset($threaded->something));
 	}
 
 	public function testThreadedCountable() {
 		$threaded = new Threaded();
 		$threaded[] = "something";
-		$this->assertEquals(count($threaded), 1);
+		$this->assertEquals(1, count($threaded));
 	}
 
 	public function testThreadedShift() {
 		$threaded = new Threaded();
 		$threaded[] = "something";
 		$threaded[] = "else";
-		$this->assertEquals($threaded->shift(), "something");
-		$this->assertEquals(count($threaded), 1);
+		$this->assertEquals("something", $threaded->shift());
+		$this->assertEquals(1, count($threaded));
 	}
 
 	public function testThreadedChunk() {
@@ -47,22 +47,22 @@ class ThreadedTest extends PHPUnit_Framework_TestCase {
 		while (count($threaded) < 10) {
 			$threaded[] = count($threaded);
 		}
-		$this->assertEquals($threaded->chunk(5), [0, 1, 2, 3, 4]);
-		$this->assertEquals(count($threaded), 5);
+		$this->assertEquals([0, 1, 2, 3, 4], $threaded->chunk(5));
+		$this->assertEquals(5, count($threaded));
 	}
 
 	public function testThreadedPop() {
 		$threaded = new Threaded();
 		$threaded[] = "something";
 		$threaded[] = "else";
-		$this->assertEquals($threaded->pop(), "else");
-		$this->assertEquals(count($threaded), 1);
+		$this->assertEquals("else", $threaded->pop());
+		$this->assertEquals(1, count($threaded));
 	}
 
 	public function testThreadedMerge() {
 		$threaded = new Threaded();
 		$threaded->merge([0, 1, 2, 3, 4]);
-		$this->assertEquals(count($threaded), 5);
+		$this->assertEquals(5, count($threaded));
 	}
 
 	public function testThreadedIterator() {
@@ -78,7 +78,7 @@ class ThreadedTest extends PHPUnit_Framework_TestCase {
 	public function testThreadedSynchronized() {
 		$threaded = new Threaded();
 		$threaded->synchronized(function(...$args){
-			$this->assertEquals($args, [1, 2, 3, 4, 5]);
+			$this->assertEquals([1, 2, 3, 4, 5], $args);
 		}, 1, 2 ,3 ,4 , 5);
 	}
 

--- a/tests/VolatileTest.php
+++ b/tests/VolatileTest.php
@@ -14,7 +14,7 @@ class VolatileTest extends PHPUnit_Framework_TestCase {
 		$threaded->test = [
 			"hello" => ["world"]];
 
-		$this->assertEquals($threaded["test"] instanceof Volatile, true);
-		$this->assertEquals($threaded["test"]["hello"] instanceof Volatile, true);
+		$this->assertTrue($threaded["test"] instanceof Volatile);
+		$this->assertTrue($threaded["test"]["hello"] instanceof Volatile);
 	}
 }

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -2,7 +2,7 @@
 class WorkerTestWork extends Threaded implements Collectable {
 	public function run() {
 		$this->synchronized(function() {
-			$this->hasWorker = 
+			$this->hasWorker =
 				$this->worker instanceof Worker;
 			$this->setGarbage();
 			$this->notify();
@@ -23,7 +23,7 @@ class WorkerTest extends PHPUnit_Framework_TestCase {
 		$worker->stack($work);
 		$worker->shutdown();
 
-		$this->assertEquals($work->hasWorker, true);
+		$this->assertTrue($work->hasWorker);
 	}
 
 	public function testWorkerGc() {
@@ -36,11 +36,11 @@ class WorkerTest extends PHPUnit_Framework_TestCase {
 				$work->wait();
 		}, $work);
 
-		$this->assertEquals($worker->collect(function ($task){
+		$this->assertEquals(1, $worker->collect(function ($task){
 			return false;
-		}), 1);	
-		$this->assertEquals($worker->collect(function ($task){
+		}));
+		$this->assertEquals(0, $worker->collect(function ($task){
 			return $task->isGarbage();
-		}), 0);
+		}));
 	}
 }


### PR DESCRIPTION
The expectation is the first argument in `assertEquals`, and the actual value the second argument. Giving arguments in the right order allows to have better error messages on failure, making the error easier to understand.
I also used `assertTrue` and `assertFalse` when checking for booleans
