### PR TITLE
Hotfix for autoloading and missing extension constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
       ".travis.yml",
       "phpunit.xml.dist",
       ".gitignore",
-      "example.php"
+      "example.php",
+      "tests"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,38 @@
 {
-    "name": "krakjoe/pthreads-polyfill",
-    "type": "library",
-    "description": "A polyfill for pthreads",
-    "keywords": ["pthreads", "polyfill"],
-    "homepage": "http://pthreads.org/",
-    "license": "PHP",
-    "authors": [
-        {
-            "name": "Joe Watkins",
-            "email": "krakjoe@php.net"
-        }
-    ],
-    "autoload": {
-        "files": [
-			"src/Collectable.php",
-			"src/Threaded.php",
-			"src/Volatile.php",
-			"src/Thread.php",
-			"src/Worker.php",
-			"src/Pool.php"
-		]
-    },
-    "minimum-stability": "dev",
-    "require-dev": {
-        "phpunit/phpunit": "^5"
+  "name": "krakjoe/pthreads-polyfill",
+  "type": "library",
+  "description": "A polyfill for pthreads",
+  "keywords": [
+    "pthreads",
+    "polyfill"
+  ],
+  "homepage": "http://pthreads.org/",
+  "license": "PHP",
+  "authors": [
+    {
+      "name": "Joe Watkins",
+      "email": "krakjoe@php.net"
     }
+  ],
+  "autoload": {
+    "psr-0": {
+      "": "src"
+    },
+    "files": [
+      "src/constants.php"
+    ]
+  },
+  "minimum-stability": "dev",
+  "require-dev": {
+    "phpunit/phpunit": "^5"
+  },
+  "archive": {
+    "exclude": [
+      ".travis.yml",
+      "phpunit.xml.dist",
+      ".gitignore",
+      "example.php"
+    ]
+  }
 }
 

--- a/src/Thread.php
+++ b/src/Thread.php
@@ -4,20 +4,20 @@ if (!extension_loaded("pthreads")) {
 	class Thread extends Threaded {
 		public function isStarted() { return (bool) ($this->state & THREAD::STARTED); }
 		public function isJoined() { return (bool) ($this->state & THREAD::JOINED); }
-		public function kill() { 
+		public function kill() {
 			$this->state |= THREAD::ERROR;
-			return true;  
+			return true;
 		}
 
 		public static function 	getCurrentThreadId() 	{ return 1; }
 		public function 			getThreadId() 			{ return 1; }
 
-		public function start() {
+		public function start($options) {
 			if ($this->state & THREAD::STARTED) {
 				throw new \RuntimeException();
 			}
 
-			$this->state |= THREAD::STARTED;		
+			$this->state |= THREAD::STARTED;
 			$this->state |= THREAD::RUNNING;
 
 			try {

--- a/src/Thread.php
+++ b/src/Thread.php
@@ -12,7 +12,7 @@ if (!extension_loaded("pthreads")) {
 		public static function 	getCurrentThreadId() 	{ return 1; }
 		public function 			getThreadId() 			{ return 1; }
 
-		public function start($options) {
+		public function start($options = null) {
 			if ($this->state & THREAD::STARTED) {
 				throw new \RuntimeException();
 			}

--- a/src/constants.php
+++ b/src/constants.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Load pthreads constants.
+ *
+ * @see http://php.net/manual/en/pthreads.constants.php
+ */
+
+if (!extension_loaded('pthreads')) {
+    /**
+     * The default options for all Threads, causes pthreads to copy the environment
+     * when new Threads are started
+     * @link http://php.net/manual/en/pthreads.constants.php
+     */
+    if (!defined('PTHREADS_INHERIT_ALL')) {
+        define('PTHREADS_INHERIT_ALL', 1118481);
+    }
+
+    /**
+     * Do not inherit anything when new Threads are started
+     * @link http://php.net/manual/en/pthreads.constants.php
+     */
+    if (!defined('PTHREADS_INHERIT_NONE')) {
+        define('PTHREADS_INHERIT_NONE', 0);
+    }
+
+    /**
+     * Inherit INI entries when new Threads are started
+     * @link http://php.net/manual/en/pthreads.constants.php
+     */
+    if (!defined('PTHREADS_INHERIT_INI')) {
+        define('PTHREADS_INHERIT_INI', 1);
+    }
+
+    /**
+     * Inherit user declared constants when new Threads are started
+     * @link http://php.net/manual/en/pthreads.constants.php
+     */
+    if (!defined('PTHREADS_INHERIT_CONSTANTS')) {
+        define('PTHREADS_INHERIT_CONSTANTS', 16);
+    }
+
+    /**
+     * Inherit user declared classes when new Threads are started
+     * @link http://php.net/manual/en/pthreads.constants.php
+     */
+    if (!defined('PTHREADS_INHERIT_CLASSES')) {
+        define('PTHREADS_INHERIT_CLASSES', 4096);
+    }
+
+    /**
+     * Inherit user declared functions when new Threads are started
+     * @link http://php.net/manual/en/pthreads.constants.php
+     */
+    if (!defined('PTHREADS_INHERIT_FUNCTIONS')) {
+        define('PTHREADS_INHERIT_FUNCTIONS', 256);
+    }
+
+    /**
+     * Inherit included file information when new Threads are started
+     * @link http://php.net/manual/en/pthreads.constants.php
+     */
+    if (!defined('PTHREADS_INHERIT_INCLUDES')) {
+        define('PTHREADS_INHERIT_INCLUDES', 65536);
+    }
+
+    /**
+     * Inherit all comments when new Threads are started
+     * @link http://php.net/manual/en/pthreads.constants.php
+     */
+    if (!defined('PTHREADS_INHERIT_COMMENTS')) {
+        define('PTHREADS_INHERIT_COMMENTS', 1048576);
+    }
+
+    /**
+     * Allow new Threads to send headers to standard output (normally prohibited)
+     * @link http://php.net/manual/en/pthreads.constants.php
+     */
+    if (!defined('PTHREADS_ALLOW_HEADERS')) {
+        define('PTHREADS_ALLOW_HEADERS', 16777216);
+    }
+}


### PR DESCRIPTION
The files were always loaded in, even when the class wasn't used.
