### PR TITLE
Fix PHP's warning

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -31,7 +31,7 @@ if (!extension_loaded("pthreads")) {
 
 		public function collect(Closure $collector = null) {
 			$total = 0;
-			foreach ($this->workers as $worker)
+			foreach ((array) $this->workers as $worker)
 				$total += $worker->collect($collector);
 			return $total;
 		}


### PR DESCRIPTION
Fix the warning "Invalid argument supplied for foreach()" when "collect" is called for an empty pool.